### PR TITLE
Container image for migrator does not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+*~
 /.gradle/
 /.idea/
 /.micronaut/

--- a/MigratorDockerfile
+++ b/MigratorDockerfile
@@ -1,0 +1,11 @@
+FROM maven:3-eclipse-temurin-11-alpine
+
+RUN mvn dependency:get -DremoteRepositories=http://repo1.maven.org/maven2/ -DgroupId=com.google.cloud.sql -DartifactId=mysql-socket-factory-connector-j-8 -Dversion=1.15.2 -Dtransitive=true
+RUN mvn dependency:get -DremoteRepositories=http://repo1.maven.org/maven2/ -DgroupId=com.mysql -DartifactId=mysql-connector-j -Dversion=8.3.0 -Dtransitive=true
+
+RUN mkdir /drivers && find /root/.m2/ -name "*.jar" | xargs cp -t /drivers
+
+FROM flyway/flyway:10-alpine
+
+COPY --from=0 /drivers /flyway/drivers
+COPY src/main/resources/db/migration /flyway/sql


### PR DESCRIPTION
Problem
-------

Deployments of the Unity Auth Service will need to migrate their database.  A convenient way of delivering this is a container image that performs the necessary migrations.  The Unity Auth Service does not have a container image for migrating the database.

Solution
--------

Add a Dockerfile for a migrator image.