### PR TITLE
Add ability to declare database connector at build time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,13 @@ dependencies {
   testImplementation("io.micronaut:micronaut-http-client")
   aotPlugins platform("io.micronaut.platform:micronaut-platform:4.2.3")
   aotPlugins("io.micronaut.security:micronaut-security-aot")
+
+  String databaseSelection = System.getenv("UNITYAUTH_DATABASE_DEPENDENCY")
+  if (databaseSelection != null) {
+    databaseSelection.split(',').each {part ->
+      runtimeOnly(part)
+    }
+  }
 }
 
 application {


### PR DESCRIPTION
Environment variables to set to configure datasource connection:

```sh
#!/bin/bash

export MICRONAUT_SERVER_PORT=8080
export UNITYAUTH_DATABASE_DEPENDENCY=mysql:mysql-connector-java:8.0.31

export DATASOURCES_DEFAULT_URL=jdbc:mysql://localhost:3306/db
export DATASOURCES_DEFAULT_DRIVER_CLASS_NAME=com.mysql.cj.jdbc.Driver
export DATASOURCES_DEFAULT_USERNAME=root
export DATASOURCES_DEFAULT_PASSWORD=pass
```