### PR TITLE
add custom login response

### DIFF
--- a/UnityAuth/src/main/java/io/unityfoundation/auth/UnityAuthenticationProvider.java
+++ b/UnityAuth/src/main/java/io/unityfoundation/auth/UnityAuthenticationProvider.java
@@ -2,16 +2,22 @@ package io.unityfoundation.auth;
 
 import static io.micronaut.security.authentication.AuthenticationFailureReason.CREDENTIALS_DO_NOT_MATCH;
 
+import io.micronaut.core.annotation.NonNull;
 import io.micronaut.core.annotation.Nullable;
 import io.micronaut.http.HttpRequest;
+import io.micronaut.security.authentication.Authentication;
 import io.micronaut.security.authentication.AuthenticationException;
 import io.micronaut.security.authentication.AuthenticationFailed;
 import io.micronaut.security.authentication.AuthenticationProvider;
 import io.micronaut.security.authentication.AuthenticationRequest;
 import io.micronaut.security.authentication.AuthenticationResponse;
+import io.micronaut.serde.annotation.Serdeable;
 import io.unityfoundation.auth.entities.User;
 import io.unityfoundation.auth.entities.UserRepo;
 import jakarta.inject.Singleton;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Schedulers;
@@ -19,54 +25,103 @@ import reactor.core.scheduler.Schedulers;
 @Singleton
 public class UnityAuthenticationProvider implements AuthenticationProvider<HttpRequest<?>> {
 
-  private final UserRepo userRepo;
-  private final PasswordEncoder passwordEncoder;
+    public static class UnityAuthentication implements Authentication {
 
-  public UnityAuthenticationProvider(UserRepo userRepo,
-      PasswordEncoder passwordEncoder) {
-    this.userRepo = userRepo;
-    this.passwordEncoder = passwordEncoder;
-  }
+        User user;
 
-  /**
-   * Authenticates the user with the given authentication request.
-   *
-   * @param httpRequest The HTTP request associated with the authentication.
-   * @param authenticationRequest The authentication request containing user credentials.
-   * @return A Publisher emitting an AuthenticationResponse upon successful authentication, or throwing
-   *         an AuthenticationException if authentication fails.
-   */
-  @Override
-  public Publisher<AuthenticationResponse> authenticate(@Nullable HttpRequest<?> httpRequest,
-      AuthenticationRequest<?, ?> authenticationRequest) {
-    return Mono.fromCallable(() -> findUser(authenticationRequest))
-        .subscribeOn(Schedulers.boundedElastic())
-        .flatMap(user -> {
-          AuthenticationFailed authenticationFailed = validate(user, authenticationRequest);
-          if (authenticationFailed != null) {
-            return Mono.error(new AuthenticationException(authenticationFailed));
-          } else {
-            return Mono.just(AuthenticationResponse.success((String) authenticationRequest.getIdentity()));
-          }
-        });  }
+        private UnityAuthentication(User user) {
+            this.user = user;
+        }
 
-  private AuthenticationFailed validate(User user,
-      AuthenticationRequest<?, ?> authenticationRequest) {
-    AuthenticationFailed authenticationFailed = null;
-    if (user == null) {
-      authenticationFailed = new AuthenticationFailed(CREDENTIALS_DO_NOT_MATCH);
-    } else if (!passwordEncoder.matches(authenticationRequest.getSecret().toString(),
-        user.getPassword())) {
-      authenticationFailed = new AuthenticationFailed(CREDENTIALS_DO_NOT_MATCH);
+        public static UnityAuthentication from(User user) {
+            return new UnityAuthentication(user);
+        }
+
+        Map<String, Object> attributes = new HashMap<>();
+
+        @Override
+        public @NonNull Map<String, Object> getAttributes() {
+            return attributes;
+        }
+
+        @Override
+        public String getName() {
+            return this.user.getEmail();
+        }
+
+        public User getUser() {
+            return this.user;
+        }
     }
 
-    return authenticationFailed;
-  }
+    @Serdeable
+    static class UnityAuthenticationResponse implements AuthenticationResponse {
 
-  private User findUser(AuthenticationRequest<?, ?> authRequest) {
-    final Object username = authRequest.getIdentity();
-    return userRepo.findUserForAuthentication(username.toString()).orElse(null);
-  }
+        Authentication authentication;
+
+        private UnityAuthenticationResponse(User user) {
+            this.authentication = UnityAuthentication.from(user);
+        }
+
+        static UnityAuthenticationResponse success(User user) {
+            return new UnityAuthenticationResponse(user);
+        }
+
+        @Override
+        public Optional<Authentication> getAuthentication() {
+            return Optional.of(authentication);
+        }
+    }
+
+    private final UserRepo userRepo;
+    private final PasswordEncoder passwordEncoder;
+
+    public UnityAuthenticationProvider(UserRepo userRepo,
+        PasswordEncoder passwordEncoder) {
+        this.userRepo = userRepo;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    /**
+     * Authenticates the user with the given authentication request.
+     *
+     * @param httpRequest           The HTTP request associated with the authentication.
+     * @param authenticationRequest The authentication request containing user credentials.
+     * @return A Publisher emitting an AuthenticationResponse upon successful authentication, or
+     * throwing an AuthenticationException if authentication fails.
+     */
+    @Override
+    public Publisher<AuthenticationResponse> authenticate(@Nullable HttpRequest<?> httpRequest,
+        AuthenticationRequest<?, ?> authenticationRequest) {
+        return Mono.fromCallable(() -> findUser(authenticationRequest))
+            .subscribeOn(Schedulers.boundedElastic())
+            .flatMap(user -> {
+                AuthenticationFailed authenticationFailed = validate(user, authenticationRequest);
+                if (authenticationFailed != null) {
+                    return Mono.error(new AuthenticationException(authenticationFailed));
+                } else {
+                    return Mono.just(UnityAuthenticationResponse.success(user));
+                }
+            });
+    }
+
+    private AuthenticationFailed validate(User user,
+        AuthenticationRequest<?, ?> authenticationRequest) {
+        AuthenticationFailed authenticationFailed = null;
+        if (user == null) {
+            authenticationFailed = new AuthenticationFailed(CREDENTIALS_DO_NOT_MATCH);
+        } else if (!passwordEncoder.matches(authenticationRequest.getSecret().toString(),
+            user.getPassword())) {
+            authenticationFailed = new AuthenticationFailed(CREDENTIALS_DO_NOT_MATCH);
+        }
+
+        return authenticationFailed;
+    }
+
+    private User findUser(AuthenticationRequest<?, ?> authRequest) {
+        final Object username = authRequest.getIdentity();
+        return userRepo.findUserForAuthentication(username.toString()).orElse(null);
+    }
 
 }
 

--- a/UnityAuth/src/main/java/io/unityfoundation/auth/UnityLoginHandler.java
+++ b/UnityAuth/src/main/java/io/unityfoundation/auth/UnityLoginHandler.java
@@ -1,0 +1,81 @@
+package io.unityfoundation.auth;
+
+import io.micronaut.context.annotation.Primary;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.HttpResponse;
+import io.micronaut.http.MutableHttpResponse;
+import io.micronaut.security.authentication.Authentication;
+import io.micronaut.security.authentication.AuthenticationResponse;
+import io.micronaut.security.handlers.LoginHandler;
+import io.micronaut.security.token.bearer.AccessRefreshTokenLoginHandler;
+import io.micronaut.security.token.generator.AccessRefreshTokenGenerator;
+import io.micronaut.security.token.render.AccessRefreshToken;
+import io.micronaut.serde.annotation.Serdeable;
+import io.unityfoundation.auth.UnityAuthenticationProvider.UnityAuthentication;
+import jakarta.inject.Singleton;
+import java.util.Optional;
+
+@Singleton
+@Primary
+public class UnityLoginHandler implements LoginHandler<HttpRequest<?>, MutableHttpResponse<?>> {
+
+    @Serdeable
+    public static class UnityLoginResponse {
+
+        AccessRefreshToken tokenInfo;
+        String firstName;
+        String lastName;
+
+        public UnityLoginResponse(AccessRefreshToken art, UnityAuthentication unityAuthentication) {
+            tokenInfo = art;
+            firstName = "todo";
+            lastName = "todo";
+//            firstName = unityAuthentication.getUser().getFirstName()
+//            lastName = unityAuthentication.getUser().getLastName();
+        }
+
+        public AccessRefreshToken getTokenInfo() {
+            return tokenInfo;
+        }
+
+        public String getFirstName() {
+            return firstName;
+        }
+
+        public String getLastName() {
+            return lastName;
+        }
+    }
+
+    AccessRefreshTokenLoginHandler accessRefreshTokenLoginHandler;
+    AccessRefreshTokenGenerator accessRefreshTokenGenerator;
+
+    public UnityLoginHandler(AccessRefreshTokenLoginHandler accessRefreshTokenLoginHandler,
+        AccessRefreshTokenGenerator accessRefreshTokenGenerator) {
+        this.accessRefreshTokenLoginHandler = accessRefreshTokenLoginHandler;
+        this.accessRefreshTokenGenerator = accessRefreshTokenGenerator;
+    }
+
+    @Override
+    public MutableHttpResponse<?> loginSuccess(Authentication authentication,
+        HttpRequest<?> request) {
+        Optional<AccessRefreshToken> accessRefreshTokenOptional = this.accessRefreshTokenGenerator.generate(
+            authentication);
+
+        return accessRefreshTokenOptional.isPresent() ? HttpResponse.ok(
+            new UnityLoginResponse(accessRefreshTokenOptional.get(),
+                (UnityAuthentication) authentication)) : HttpResponse.serverError();
+    }
+
+    @Override
+    public MutableHttpResponse<?> loginRefresh(Authentication authentication, String refreshToken,
+        HttpRequest<?> request) {
+        return accessRefreshTokenLoginHandler.loginRefresh(authentication, refreshToken, request);
+    }
+
+    @Override
+    public MutableHttpResponse<?> loginFailed(AuthenticationResponse authenticationResponse,
+        HttpRequest<?> request) {
+        return accessRefreshTokenLoginHandler.loginFailed(authenticationResponse, request);
+    }
+}


### PR DESCRIPTION
example of custom login response by returning custom instance of `Authentication` in the `AuthenticationProvider` and using our custom Authentication instance inside of the `LoginHandler` to create a custom response.