### PR TITLE
Consolidate ports for Docker and local environments

### DIFF
--- a/DockerfileFrontend-dev
+++ b/DockerfileFrontend-dev
@@ -4,7 +4,7 @@ COPY frontend frontend
 WORKDIR frontend
 RUN npm install
 
-EXPOSE 3000
+EXPOSE 3001
 
 # Start the app in development mode
 ENTRYPOINT ["npm", "run", "dev"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ source setenv.sh
 cd UnityAuth
 ./gradlew run
 ```
+This starts the UnityAuth API server on http://localhost:9090 if the `MICRONAUT_ENVIRONMENTS`
+environment variable contains `local`.
 
 Run the UnityAuth UI in another terminal windows:
 ```shell
@@ -29,6 +31,7 @@ cd frontend
 npm install
 npm run dev
 ```
+This starts the frontend on http://localhost:3001.
 
 ### Docker Environment
 To launch the auth service, you can use the docker compose from the project root:
@@ -41,7 +44,7 @@ This will start containers for the UnityAuth API, UI and database server with se
 names `unity-auth-api`, `unity-auth-ui`, and `unity-auth-db`, respectively.
 
 - **UnityAuth API** on http://localhost:9090 (inside Docker http://unity-auth-api:9090)
-- **UnityAuth UI** on http://localhost:3001 (inside Docker http://unity-auth-ui:3000)
+- **UnityAuth UI** on http://localhost:3001 (inside Docker http://unity-auth-ui:3001)
 - **MySQL Database** is open on port `13306` in `localhost` (within Docker is port `3306`
   with host name `unity-auth-db`)
 
@@ -72,7 +75,8 @@ This repository contains three main subprojects:
 
 ### 1. UnityAuth (Main Service)
 
-**Location:** `/UnityAuth/`
+**Location:** `/UnityAuth`
+
 **Technology:** Java 21 + Micronaut Framework
 
 The core authentication service that provides:
@@ -94,7 +98,8 @@ The core authentication service that provides:
 
 ### 2. AuthGenHash (Utility Tool)
 
-**Location:** `/AuthGenHash/`
+**Location:** `/AuthGenHash`
+
 **Technology:** Java 17 + Micronaut + PicoCLI
 
 A command-line utility for generating secure password hashes compatible with the UnityAuth service.
@@ -107,7 +112,8 @@ A command-line utility for generating secure password hashes compatible with the
 
 ### 3. Frontend (Web Administration Interface)
 
-**Location:** `/frontend/`
+**Location:** `/frontend`
+
 **Technology:** SvelteKit + TypeScript + Tailwind CSS
 
 A modern web application providing administrative interface for the UnityAuth service.

--- a/UnityAuth/src/main/resources/application-docker.yml
+++ b/UnityAuth/src/main/resources/application-docker.yml
@@ -18,6 +18,7 @@ micronaut:
             - localhost:3000
             - http://127.0.0.1:3000
             - http://libre311-ui:3000
+            - http://libre311-ui-dev:3000
             - http://localhost:3001
             - localhost:3001
             - http://127.0.0.1:3001

--- a/UnityAuth/src/main/resources/application-local.yml
+++ b/UnityAuth/src/main/resources/application-local.yml
@@ -11,11 +11,15 @@ micronaut:
             - http://localhost:3000
             - localhost:3000
             - http://127.0.0.1:3000
+            - http://libre311-ui:3000
+            - http://libre311-ui-dev:3000
             - http://localhost:3001
             - localhost:3001
             - http://127.0.0.1:3001
+            - http://unity-auth-ui:3001
+            - http://unity-auth-ui-dev:3001
       localhost-pass-through: true
-    port: 8081
+    port: 9090
   security:
     authentication: bearer
 datasources:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -30,7 +30,7 @@ services:
     environment:
       VITE_BACKEND_URL: http://unity-auth-api:9090
     ports:
-      - "3001:3000"
+      - "3001:3001"
 
   ## UI Service - Production environment
   ## Start by: docker compose -f docker-compose.local.yml --profile prod up

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,7 @@
 			"devDependencies": {
 				"@playwright/test": "^1.28.1",
 				"@sveltejs/adapter-auto": "^3.0.0",
-        "@sveltejs/adapter-static": "^3.0.1",
+				"@sveltejs/adapter-static": "^3.0.1",
 				"@sveltejs/kit": "^2.0.0",
 				"@sveltejs/vite-plugin-svelte": "^3.0.0",
 				"@tailwindcss/forms": "^0.5.7",

--- a/frontend/setenv.sh
+++ b/frontend/setenv.sh
@@ -1,1 +1,1 @@
-export VITE_BACKEND_URL=http://127.0.0.1:8081
+export VITE_BACKEND_URL=http://127.0.0.1:9090

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
 		include: ['src/**/*.{test,spec}.{js,ts}']
 	},
 	server: {
-		port: 3000,
+		port: 3001,
 		host: true
 	}
 });


### PR DESCRIPTION
- Use port 9090 for the API server and 3001 for the frontend consistently across the local and Docker environments